### PR TITLE
Test PR comment functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write  # Required for PR comments
 
 jobs:
   pre-commit:
@@ -132,3 +133,34 @@ jobs:
             echo "Expected 0 compatible changes, got ${{ steps.test-clean.outputs.compatible-count }}"
             exit 1
           fi
+
+  # Test PR comment functionality (only on PRs)
+  test-pr-comment:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build action
+        run: |
+          npm ci
+          npm run build
+
+      # Test with breaking changes and PR comment enabled
+      - name: Test PR comment with breaking changes
+        uses: ./
+        with:
+          working-directory: testdata/break
+          fail-on-breaking: false
+          comment-on-pr: true
+        env:
+          INPUT_OLD: old
+          INPUT_NEW: new

--- a/test-file.txt
+++ b/test-file.txt
@@ -1,0 +1,4 @@
+This file is added to demonstrate the PR comment feature of apidiff-action.
+
+When this PR is opened, the test-pr-comment job will run and create a comment
+showing the API changes detected in the testdata/break example.


### PR DESCRIPTION
## Summary

This PR tests the apidiff-action's ability to comment on pull requests when breaking API changes are detected.

## Changes

- Add `pull-requests: write` permission to CI workflow
- Add new `test-pr-comment` job that runs only on PRs
- Enable `comment-on-pr: true` for the breaking changes test

## Expected Result

When this PR is merged, the action should automatically add a comment showing:

```markdown
# API Compatibility Check Results

## Summary

| Type | Count |
|------|-------|
| Breaking changes | 3 |
| Compatible changes | 1 |

⚠️ **This PR contains breaking API changes\!**

## Details

#### ❌ Breaking changes

- (*Greeter).Greet: changed from func() string to func(bool) string
- MaxRetries: removed
- Process: changed from func(string) (string, error) to func(context.Context, string) (string, error)

#### ✅ Compatible changes

- Greeter.Language: added
```

This demonstrates the action working on real PRs to help reviewers understand API changes.

🤖 Generated with [Claude Code](https://claude.ai/code)