### PR TITLE
Exclude package-lock.json from pretty-format-json hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-json
       - id: pretty-format-json
         args: ['--autofix']
+        exclude: ^package-lock\.json$
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0


### PR DESCRIPTION
## Summary
- Excludes `package-lock.json` from the pretty-format-json pre-commit hook
- Prevents Dependabot PRs from failing CI due to formatting differences

## Why this change?
We discovered in #6 that Dependabot PRs were failing because the auto-generated `package-lock.json` didn't match the formatting expected by the pretty-format-json hook. Since `package-lock.json` is auto-generated by npm, its exact formatting doesn't matter as long as it's valid JSON.

## Test plan
- [x] Verified that `package-lock.json` is excluded: `pre-commit run pretty-format-json --files package-lock.json` shows "(no files to check)Skipped"
- [x] Verified that other JSON files are still checked: `pre-commit run pretty-format-json --files package.json` passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)